### PR TITLE
Fixed multiple definition errors

### DIFF
--- a/cpp/include/celerite/banded.h
+++ b/cpp/include/celerite/banded.h
@@ -8,7 +8,7 @@ namespace celerite {
 #define SWAP(a,b) {dum=(a);(a)=(b);(b)=dum;}
 #define TINY 1.0e-20
 
-size_t get_index (size_t i, size_t j, size_t dx)
+inline size_t get_index (size_t i, size_t j, size_t dx)
 {
   return (i-1)*dx + (j-1);
 }

--- a/cpp/include/celerite/lapack.h
+++ b/cpp/include/celerite/lapack.h
@@ -52,7 +52,7 @@ extern "C" void dgtsv_(int* n,
 namespace celerite {
 
 // Real band solver:
-int band_factorize (int m, int kl, int ku, Eigen::MatrixXd& ab, Eigen::VectorXi& ipiv) {
+inline int band_factorize (int m, int kl, int ku, Eigen::MatrixXd& ab, Eigen::VectorXi& ipiv) {
   int n = ab.cols(),
       ldab = ab.outerStride(),
       info;
@@ -60,7 +60,7 @@ int band_factorize (int m, int kl, int ku, Eigen::MatrixXd& ab, Eigen::VectorXi&
   return info;
 }
 
-int band_solve (int kl, int ku,
+inline int band_solve (int kl, int ku,
                 const Eigen::MatrixXd& ab,
                 const Eigen::VectorXi& ipiv,
                 Eigen::MatrixXd& x) {
@@ -73,7 +73,7 @@ int band_solve (int kl, int ku,
   return info;
 }
 
-Eigen::MatrixXd band_dot (int kl, int ku, const Eigen::MatrixXd& a, const Eigen::MatrixXd& x) {
+inline Eigen::MatrixXd band_dot (int kl, int ku, const Eigen::MatrixXd& a, const Eigen::MatrixXd& x) {
   double one = 1.0;
   char trans = 'N';
   int ione = 1,

--- a/cpp/include/celerite/solver/solver.h
+++ b/cpp/include/celerite/solver/solver.h
@@ -8,8 +8,9 @@
 namespace celerite {
 namespace solver {
 
-int SOLVER_DIMENSION_MISMATCH = 1;
-int SOLVER_NOT_COMPUTED = 2;
+// You should probably be using an enum class for this
+const int SOLVER_DIMENSION_MISMATCH = 1;
+const int SOLVER_NOT_COMPUTED = 2;
 
 template <typename T>
 class Solver {


### PR DESCRIPTION
There was a function defined globally in a .h file, not in a class. I needed to add inline to get it to work, otherwise if I included celerite.h files more than once I got "multiple definition" linker errors. There were also two global ints defined in a .h file, which needed to be const.

See here:
http://stackoverflow.com/questions/2225435/how-do-i-create-a-header-only-library
http://stackoverflow.com/questions/33464242/c-multiple-definition-of-variable-even-with-extern