### PR TITLE
move to std:chrono for timer

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -79,7 +79,7 @@ add_definitions(-DNDEBUG)
 add_subdirectory(src)
 
 # Setup installation of public headers.
-file(GLOB CELERITE_HDRS ${CMAKE_SOURCE_DIR}/include/celerite/*.h)
-install(FILES ${CELERITE_HDRS} DESTINATION include/celerite)
-file(GLOB CELERITE_SOLVER_HDRS ${CMAKE_SOURCE_DIR}/include/celerite/solver/*.h)
-install(FILES ${CELERITE_SOLVER_HDRS} DESTINATION include/celerite/solver)
+#file(GLOB CELERITE_HDRS ${CMAKE_SOURCE_DIR}/include/celerite/*.h)
+#install(FILES ${CELERITE_HDRS} DESTINATION include/celerite)
+#file(GLOB CELERITE_SOLVER_HDRS ${CMAKE_SOURCE_DIR}/include/celerite/solver/*.h)
+#install(FILES ${CELERITE_SOLVER_HDRS} DESTINATION include/celerite/solver)

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_CXX_STANDARD 11)
+set( CMAKE_CXX_EXTENSIONS OFF)
+
 macro (CELERITE_EXEC NAME)
     add_executable(${NAME} ${NAME}.cc)
     target_link_libraries(${NAME} ${CELERITE_LIBRARIES})

--- a/cpp/src/benchmark.cc
+++ b/cpp/src/benchmark.cc
@@ -1,15 +1,19 @@
 #include <iostream>
-#include <sys/time.h>
 #include <Eigen/Core>
 
 #include "celerite/celerite.h"
 
+#include <chrono>
+
+
 // Timer for the benchmark.
+//http://jakascorner.com/blog/2016/04/time-measurement.html
 double get_timestamp ()
 {
-  struct timeval now;
-  gettimeofday (&now, NULL);
-  return double(now.tv_usec) * 1.0e-6 + double(now.tv_sec);
+  using micro_s = std::chrono::microseconds;
+  auto tnow = std::chrono::steady_clock::now();
+  auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
+  return double(d_micro) * 1.0e-6;
 }
 
 int main (int argc, char* argv[])

--- a/cpp/src/benchmark.cc
+++ b/cpp/src/benchmark.cc
@@ -1,20 +1,29 @@
 #include <iostream>
 #include <Eigen/Core>
-
 #include "celerite/celerite.h"
 
-#include <chrono>
-
-
 // Timer for the benchmark.
-//http://jakascorner.com/blog/2016/04/time-measurement.html
-double get_timestamp ()
-{
-  using micro_s = std::chrono::microseconds;
-  auto tnow = std::chrono::steady_clock::now();
-  auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
-  return double(d_micro) * 1.0e-6;
-}
+#if defined(_MSC_VER)
+    //no sys/time.h in visual c++
+    //http://jakascorner.com/blog/2016/04/time-measurement.html
+    #include <chrono>
+    double get_timestamp ()
+    {
+      using micro_s = std::chrono::microseconds;
+      auto tnow = std::chrono::steady_clock::now();
+      auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
+      return double(d_micro) * 1.0e-6;
+    }
+#else
+   //no std::chrono in g++ 4.8
+   #include <sys/time.h>
+   double get_timestamp ()
+   {
+     struct timeval now;
+     gettimeofday (&now, NULL);
+     return double(now.tv_usec) * 1.0e-6 + double(now.tv_sec);
+   }  
+#endif
 
 int main (int argc, char* argv[])
 {

--- a/cpp/src/carma_comp.cc
+++ b/cpp/src/carma_comp.cc
@@ -1,20 +1,24 @@
 #include <iostream>
 #include <cmath>
 #include <complex>
-#include <sys/time.h>
 #include <Eigen/Core>
 
 #include "celerite/celerite.h"
 #include "celerite/carma.h"
 #include "celerite/utils.h"
+#include <chrono>
+
 
 // Timer for the benchmark.
+//http://jakascorner.com/blog/2016/04/time-measurement.html
 double get_timestamp ()
 {
-  struct timeval now;
-  gettimeofday (&now, NULL);
-  return double(now.tv_usec) * 1.0e-6 + double(now.tv_sec);
+  using micro_s = std::chrono::microseconds;
+  auto tnow = std::chrono::steady_clock::now();
+  auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
+  return double(d_micro) * 1.0e-6;
 }
+
 
 int main (int argc, char* argv[])
 {

--- a/cpp/src/carma_comp.cc
+++ b/cpp/src/carma_comp.cc
@@ -6,18 +6,32 @@
 #include "celerite/celerite.h"
 #include "celerite/carma.h"
 #include "celerite/utils.h"
-#include <chrono>
+
 
 
 // Timer for the benchmark.
-//http://jakascorner.com/blog/2016/04/time-measurement.html
-double get_timestamp ()
-{
-  using micro_s = std::chrono::microseconds;
-  auto tnow = std::chrono::steady_clock::now();
-  auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
-  return double(d_micro) * 1.0e-6;
-}
+#if defined(_MSC_VER)
+    //no sys/time.h in visual c++
+    //http://jakascorner.com/blog/2016/04/time-measurement.html
+    #include <chrono>
+    double get_timestamp ()
+    {
+      using micro_s = std::chrono::microseconds;
+      auto tnow = std::chrono::steady_clock::now();
+      auto d_micro = std::chrono::duration_cast<micro_s>(tnow.time_since_epoch()).count();
+      return double(d_micro) * 1.0e-6;
+    }
+#else
+   //no std::chrono in g++ 4.8
+   #include <sys/time.h>
+   double get_timestamp ()
+   {
+     struct timeval now;
+     gettimeofday (&now, NULL);
+     return double(now.tv_usec) * 1.0e-6 + double(now.tv_sec);
+   }  
+#endif
+
 
 
 int main (int argc, char* argv[])


### PR DESCRIPTION
caveat -- this is literally the first code I've ever compiled for windows

working for me with visual studio c++ on windows 10 and g++ 5.3 on osx maverick

with CXX=clang on maverick it fails to compile test_poly.cc with:

     symbols for architecture x86_64:
      "std::__1::__vector_base_common<true>::__throw_length_error() const", referenced from:

for unix programmers new to visual studio 2017 I compiled using:

    cd celerite/cpp
    mkdir build64
    cd build64
    cmake -G "Visual Studio 14 2015 Win64" ..
    cd ..
    cmake --build build64 --target run_tests --config Release






