### PR TITLE
Removed semicolons

### DIFF
--- a/cpp/include/celerite/carma.h
+++ b/cpp/include/celerite/carma.h
@@ -285,7 +285,7 @@ private:
 
 }; // class CARMASolver
 
-}; // namespace carma
-}; // namespace celerite
+} // namespace carma
+} // namespace celerite
 
 #endif // _CELERITE_CARMA_H_

--- a/cpp/include/celerite/exceptions.h
+++ b/cpp/include/celerite/exceptions.h
@@ -35,6 +35,6 @@ struct linalg_exception : public std::exception {
   }
 };
 
-}; // namespace celerite
+} // namespace celerite
 
 #endif // _CELERITE_EXCEPTIONS_H_

--- a/cpp/include/celerite/poly.h
+++ b/cpp/include/celerite/poly.h
@@ -137,6 +137,6 @@ inline int polycountroots (const Eigen::Matrix<T, Eigen::Dynamic, 1>& p) {
   return count;
 }
 
-};
+} // namespace celerite
 
 #endif

--- a/cpp/include/celerite/solver/cholesky.h
+++ b/cpp/include/celerite/solver/cholesky.h
@@ -707,7 +707,7 @@ Eigen::VectorXd t_;
 
 };
 
-};
-};
+}
+}
 
 #endif

--- a/cpp/include/celerite/solver/direct.h
+++ b/cpp/include/celerite/solver/direct.h
@@ -138,7 +138,7 @@ using Solver<T>::compute;
 
 };
 
-};
-};
+}
+}
 
 #endif

--- a/cpp/include/celerite/solver/solver.h
+++ b/cpp/include/celerite/solver/solver.h
@@ -207,7 +207,7 @@ void compute (
 };
 
 }; // class Solver
-}; // namespace solver
-}; // namespace celerite
+} // namespace solver
+} // namespace celerite
 
 #endif

--- a/cpp/include/celerite/utils.h
+++ b/cpp/include/celerite/utils.h
@@ -162,6 +162,6 @@ inline get_psd_value (
   return sqrt(2.0 / M_PI) * p;
 }
 
-};
+} // namespace celerite
 
 #endif


### PR DESCRIPTION
I compile with gcc options `-Wall -Wextra -pedantic`, and pedantic was giving a warning about semicolons at the end of namespaces. So I have removed those to cut down on compiler noise.