### PR TITLE
Correct AttributeError from Conditional Statements (k1._has_jitter)

### DIFF
--- a/celerite/terms.py
+++ b/celerite/terms.py
@@ -218,7 +218,13 @@ class Term(Model):
 class TermProduct(Term, ModelSet):
 
     def __init__(self, k1, k2):
-        if k1._has_jitter or k2._has_jitter:
+        _has_jitter = False
+        if hasattr(k1, '_has_jitter') and k1._has_jitter:
+            _has_jitter = True
+        if hasattr(k1, '_has_jitter') and k1._has_jitter:
+            _has_jitter = True
+        
+        if _has_jitter:
             raise ValueError("Products are not implemented for terms with "
                              "jitter")
         super(TermProduct, self).__init__([("k1", k1), ("k2", k2)])


### PR DESCRIPTION
[terms.py: Line 221] raises an AttributeError for kernels lacking the `_has_jitter` flag attribute.

Not all kernels include the flag attribute `_has_jitter`; and therefore, when multiplying 2 kernels that do not include the `_has_jitter` flag, the original version of this condition `if k1._has_jitter or k2._has_jitter` raises an AttributeError: "`k1` does not have the attribute `_has_jitter`" (paraphrased).

By checking if the kernel `k1` or `k2` has the attribute `_has_jitter` at all, before checking if it will return True/False mitigates this AttributeError.