### PR TITLE
Add test and fix for quiet kwarg

### DIFF
--- a/celerite/modeling.py
+++ b/celerite/modeling.py
@@ -65,6 +65,9 @@ class Model(object):
             raise ValueError("the bounds for each parameter must have the "
                              "format: '(min, max)'")
 
+        # Deal with "quiet" kwarg
+        quiet = kwargs.pop("quiet", False)
+
         # Parameter values can be specified as arguments or keywords
         if len(args):
             if len(args) != self.full_size:
@@ -90,7 +93,6 @@ class Model(object):
                                  .format(list(kwargs.keys())))
 
         # Check the initial prior value
-        quiet = kwargs.get("quiet", False)
         if not quiet and not np.isfinite(self.log_prior()):
             raise ValueError("non-finite log prior value")
 

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -117,3 +117,18 @@ def test_jitter_jacobian(k, eps=1.34e-7):
         jac0[i] = 0.5 * jitter / eps
         v[i] = pval
     assert np.allclose(jac, jac0)
+
+
+def test_quiet():
+
+    # Quiet is accepted as kwarg without raising error
+    terms.RealTerm(log_a=0.1, log_c=0.5, quiet=True)
+
+    # Complex with log_a+log_c < log_b+log_d properly fails when quiet=False
+    with pytest.raises(ValueError):
+        terms.ComplexTerm(log_a=1.0, log_b=10.0, log_c=1.0, log_d=1.0)
+
+    # quiet=True makes the above raise no error
+    terms.ComplexTerm(
+        log_a=1.0, log_b=10.0, log_c=1.0, log_d=1.0, quiet=True
+    )

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -123,10 +123,15 @@ def test_quiet():
 
     # Quiet is accepted as kwarg without raising error
     terms.RealTerm(log_a=0.1, log_c=0.5, quiet=True)
+    terms.RealTerm(0.1, 0.5, quiet=True)  # Same as above but with args
 
     # Complex with log_a+log_c < log_b+log_d properly fails when quiet=False
     with pytest.raises(ValueError):
         terms.ComplexTerm(log_a=1.0, log_b=10.0, log_c=1.0, log_d=1.0)
+    with pytest.raises(ValueError):
+        terms.ComplexTerm(
+            log_a=1.0, log_b=10.0, log_c=1.0, log_d=1.0, quiet=False
+        )
 
     # quiet=True makes the above raise no error
     terms.ComplexTerm(


### PR DESCRIPTION
This fixes #171 by `quiet = kwargs.pop("quiet", False)` near the top of the `__init__()` method (just after the bounds are popped).

I also added `test_quiet()` in `test_terms.py` to test that the keyword can be used and that it has the expected effect.